### PR TITLE
[success] 전력망 둘로 나누기 #1

### DIFF
--- a/nodeJS/Programmers/260109/solution.js
+++ b/nodeJS/Programmers/260109/solution.js
@@ -1,0 +1,66 @@
+/**
+입출력 예
+n = 9	
+wires = [[1,3],[2,3],[3,4],[4,5],[4,6],[4,7],[7,8],[7,9]]	
+    result = 3
+n = 4	
+wires = [[1,2],[2,3],[3,4]]	
+    result = 0
+n = 7	
+wires = [[1,2],[2,7],[3,7],[3,4],[4,5],[6,7]]	
+    result = 1
+*/
+
+// 예시 입력
+const n = 7	;
+const wires = [[1,2],[2,7],[3,7],[3,4],[4,5],[6,7]]	;
+
+// 예시 출력
+const result = solution(n, wires);
+console.log(result);
+
+// 풀이 시작
+function solution(n, wires) {
+    let answer = -1;
+    // 방문 기록용 배열
+    const visited = new Array(n + 1).fill(false);
+    // 인접 리스트 생성
+    const graph = Array.from({ length: n + 1 }, () => []);
+    for (const [v1, v2] of wires) {
+        graph[v1].push(v2);
+        graph[v2].push(v1);
+    }
+    
+    // DFS 함수
+    function dfs(node) {
+        visited[node] = true;
+        let count = 1; // 현재 노드 포함
+        for (const neighbor of graph[node]) {
+            if (!visited[neighbor]) {
+                count += dfs(neighbor);
+            }
+        }
+        return count;
+    }
+    
+    let minDiff = Infinity;
+    
+    // 각 전선을 끊어보며 탐색
+    for (const [v1, v2] of wires) {
+        // 방문 기록 초기화
+        visited.fill(false);
+        
+        // 끊은 전선의 한쪽 노드부터 DFS 시작
+        visited[v2] = true; // 끊은 쪽 노드 방문 처리
+        const count1 = dfs(v1);
+        const count2 = n - count1;
+        
+        const diff = Math.abs(count1 - count2);
+        if (diff < minDiff) {
+            minDiff = diff;
+        }
+    }
+    
+    answer = minDiff;
+    return answer;
+}


### PR DESCRIPTION
문제:  #1 

---

## 결과
- 정확성: 100.0
- 합계: 100.0 / 100.0

---

## 풀이 방법

### 문제 접근 방법
전력망은 **사이클이 없는 트리 구조**이므로,   
전선(간선)을 하나 제거하면 네트워크는 항상 2개의 연결 컴포넌트로 분리된다.

각 전선을 하나씩 끊어보며:
- 한쪽 컴포넌트의 송전탑 개수 구하고
- 나머지는 `n-count`로 계산하여
- 두 컴포넌트 간 송전탑 개수 차이의 최솟값을 구한다.

### 해결 전략
1. 전력망을 **인접 리스트 그래프**로 구성
2. 모든 전선을 하나씩 제거한다고 가정
3. 제거한 전선의 한쪽 노드에서 **DFS탐색**
4. 탐색된 노드 수를 기준으로 두 네트워크 크기 차이 계산
5. 모든 경우 중 최소 차이를 결과로 반환

### 구현 핵심 포인트
- 전선을 실제로 제거하지 않고
    - DFS 시작 전에 끊은 전선의 반대편 노드를 `visited`처리하여
    - 해당 전선이 탐색되지 않도록 처리
-  DFS는 현재 노드를 포함한 **연결된 노드 수를 반환**
- 각 전선마다 `visited`배열을 초기화하여 독립적으로 탐색

```js
visited[v2] = true; // 끊은 전선의 반대편을 미리 방문 처리
const count1 = dfs(v1);
const count2 = n - count1;
```

### 시간 복잡도
- 전선 수: `n-1`
- 각 전선마다 DFS 탐색: `O(n)`
> 전체 시간 복잡도: O(n²)


